### PR TITLE
Bug--Search history remove button doesn't remove searches (fixed)

### DIFF
--- a/src/client/app/core/saved-records-service.js
+++ b/src/client/app/core/saved-records-service.js
@@ -169,7 +169,7 @@
             if(type === SAVED_ITEMS.recordKey) {
               return record._id !== item._id;
             } else {
-              return !_.isEqual(item, record);
+              return item.time !== record.time;
             }
           });
           items[type] = newRecords;

--- a/src/client/app/core/saved-records.unit.spec.js
+++ b/src/client/app/core/saved-records.unit.spec.js
@@ -123,10 +123,14 @@ describe("Saved Records Service", function() {
     it('should remove searches', function() {
       var timestamp = Date.now();
       SavedRecordsService.saveSearch(opts, numResults, timestamp);
+      opts.q = "new term";
+      SavedRecordsService.saveSearch(opts, numResults, Date.now() + 10);
+      opts.q = "another new term";
+      SavedRecordsService.saveSearch(opts, numResults, Date.now() + 20);
       var searches = SavedRecordsService.getSearches();
       SavedRecordsService.removeSearch(searches[0]);
       var remainingSearches = SavedRecordsService.getSearches();
-      expect(remainingSearches.length).toEqual(0);
+      expect(remainingSearches.length).toEqual(2);
     });
 
     it('should save searches when previous searches are not in correct format', function() {

--- a/test/e2e/saved-records.e2e.spec.js
+++ b/test/e2e/saved-records.e2e.spec.js
@@ -123,19 +123,27 @@ describe('Saved Records Page', function() {
     });
   });
 
-  it('should remove searches when clicking the remove button', function () {
+  fit('should remove searches when clicking the remove button', function () {
     resultsPage.submitNewSearchTerm('painting');
     browser.waitForAngular();
+    resultsPage.submitNewSearchTerm('history');
+    resultsPage.submitNewSearchTerm('England');
+    resultsPage.getQueryTerms().get(0).click();
+    resultsPage.getQueryTerms().get(0).click();
+    resultsPage.getQueryTerms().get(0).click();
     savedRecordsPage = new SavedRecordsPage();
     savedRecordsPage.clickRecentSearches();
     browser.waitForAngular();
-    savedRecordsPage.getAllSearches().then(function(searches) {
-      expect(searches.length).toBe(3);
-    });
+    expect(savedRecordsPage.getAllSearches().count()).toBe(7);
     savedRecordsPage.removeSearch(0);
-    savedRecordsPage.getAllSearches().then(function(searches) {
-      expect(searches.length).toBe(2);
-    });
+    expect(savedRecordsPage.getAllSearches().count()).toBe(6);
+    savedRecordsPage.removeSearch(1);
+    savedRecordsPage.removeSearch(1);
+    savedRecordsPage.removeSearch(1);
+    savedRecordsPage.removeSearch(1);
+    savedRecordsPage.removeSearch(1);
+    savedRecordsPage.removeSearch(0);
+    expect(savedRecordsPage.getAllSearches().count()).toBe(0);
   });
 
 });

--- a/test/e2e/saved-records.e2e.spec.js
+++ b/test/e2e/saved-records.e2e.spec.js
@@ -123,7 +123,7 @@ describe('Saved Records Page', function() {
     });
   });
 
-  fit('should remove searches when clicking the remove button', function () {
+  it('should remove searches when clicking the remove button', function () {
     resultsPage.submitNewSearchTerm('painting');
     browser.waitForAngular();
     resultsPage.submitNewSearchTerm('history');


### PR DESCRIPTION
Closes #485 

I was comparing the entire "search object" that I had stored, but that was prone to error. Instead I'm now comparing the timestamp of the search (which I store) because they will be unique to each search. There were existing tests for this, but I made them a bit stronger.

**Reviewers**
- [x] @joshuago78 
- [ ] @adamcee 
- [ ] @kristenGRI 