### PR TITLE
Disable Angular debug mode in production for performance improvement

### DIFF
--- a/config/local/app.env.config.json
+++ b/config/local/app.env.config.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "env": "local",
     "elastic": {
       "host": "local.portal.dev",
       "port": "9200",

--- a/src/client/app/app.env.config.js
+++ b/src/client/app/app.env.config.js
@@ -1,5 +1,5 @@
 (function () { 
  return angular.module("app.env.config", [])
-.constant("config", {"elastic":{"host":"local.portal.dev","port":"9200","apiVersion":"2.0"},"app":{"root":"app"},"django":{"host":"http://127.0.0.1","port":"8000"}});
+.constant("config", {"env":"local","elastic":{"host":"local.portal.dev","port":"9200","apiVersion":"2.0"},"app":{"root":"app"},"django":{"host":"http://127.0.0.1","port":"8000"}});
 
 })();

--- a/src/client/app/app.module.js
+++ b/src/client/app/app.module.js
@@ -23,6 +23,17 @@
   // make lodash injectable
   .constant('_', window._)
 
+  // turn off angular debug mode for production; improves performance
+  .config(['$compileProvider', 'config', function($compileProvider, config){
+    if(config.env === 'prod'){
+      $compileProvider.debugInfoEnabled(false);
+      console.log('In production. Debug mode disabled');
+    }
+    else{
+      console.log('In ' + config.env + '. Debug mode enabled');
+    }
+  }])
+
   .run(['$rootScope', '$state', '$stateParams', function($rootScope, $state, $stateParams){
     // Convenience to access things any scope w/out injection
     $rootScope.$state = $state;


### PR DESCRIPTION
Closes #515 
Angular App now has `config.env` property. This is set using the gulp config process as documented in Confluence. When `config.env` equals "prod", Angular debug mode is disabled which should decrease load times by roughly 1/2. 

**To Test Locally**
From portal root:
`mkdir config/prod`
`cp config/local/app.env.config.json config/prod`
Change the `env` setting in `config/prod/app.env.config.json` to equal "prod"
`gulp clean:config`
`gulp config:prod`
If you get an error you may need to run `sudo npm install` or `npm install` to install grunt

Start up the app. Check the console. There should be a message saying the app is running in production with debug mode off.

Run:
`gulp clean:config`
`gulp config:local`

Start the app. Check the console. There should be a message saying the app is running in local with debug mode on.

--------
PR Review

- [ ] @jfranco-gri 
- [x] @joshuago78 