### PR TITLE
Bug/handle elasticsearch exception/518

### DIFF
--- a/src/server/api/tests.py
+++ b/src/server/api/tests.py
@@ -1,10 +1,12 @@
+import json
+
 from django.test import TestCase, RequestFactory
 from rest_framework.test import APIRequestFactory, APITestCase
-from api.views import Book, Raw, Books, Contributors
-from . import es_functions
-from api.renderers import RISRenderer
+from rest_framework import status
 
-import json
+from api.views import Book, Raw, Books, Contributors
+from api.renderers import RISRenderer
+from . import es_functions
 
 
 class APITests(APITestCase):
@@ -37,6 +39,15 @@ class APITests(APITestCase):
         request = self.factory.get('/api/book/gri_9921975010001551')
         response = book(request, 'gri_9921975010001551')
         self.assertEqual(response.data, book_data)
+
+    def test_bad_book_id(self):
+        book = Book.as_view()
+        test_id = 'bad_book_id'
+        request = self.factory.get('/api/book/' + test_id)
+        response = book(request, test_id)
+        self.assertFalse(response.data['found'])
+        self.assertEqual(response.data['_id'], test_id)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_ris(self):
         book = Raw.as_view()

--- a/src/server/api/views.py
+++ b/src/server/api/views.py
@@ -20,13 +20,10 @@ class Raw(APIView):
     def get(self, request, id, format=None):
         es = Elasticsearch([ELASTICSEARCH_ADDRESS])
         book_id = id
-
         try:
             response = es.get(index='portal', doc_type='book', id=book_id, request_timeout=30)
         except NotFoundError as err:
             return Response(err.info, status=status.HTTP_404_NOT_FOUND)
-        except Exception:
-            return Response('Something went wrong with Elasticsearch', status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         data = json.loads(json.dumps(response))
         return Response(data, status=status.HTTP_200_OK)
 
@@ -39,8 +36,6 @@ class Book(APIView):
             response = es.get(index='portal', doc_type='book', id=book_id, request_timeout=30)
         except NotFoundError as err:
             return Response(err.info, status=status.HTTP_404_NOT_FOUND)
-        except Exception:
-            return Response('Something went wrong with Elasticsearch', status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         dc = dc_export(response)
         data = json.loads(json.dumps(dc))
         return Response(data, status=status.HTTP_200_OK)
@@ -94,10 +89,7 @@ class Books(APIView):
                         body['aggregations'][other_category]['filter']['bool']['must'].append(facet_filters)
 
         query = es_functions.create_multisearch(body, search_options.get('from'), search_options.get('size'), filters)
-        try:
-            response = es.msearch(body=query)
-        except Exception:
-            return Response('Something went wrong with Elasticsearch', status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        response = es.msearch(body=query)
         data = json.loads(json.dumps(response))
         return Response(data['responses'], status=status.HTTP_200_OK)
 


### PR DESCRIPTION
Closes #518 

If Elasticsearch can't find a book record, this catches the exception Elasticsearch throws and then returns a 404 status back to the angular app, instead of a 500 status as it was doing before.  It also returns the error info from elasticsearch, which contains the book id.  If any other problem with elasticsearch occurs, django will send a 500 error by default.