### PR TITLE
Bug/disable hover elements touch/517

### DIFF
--- a/src/client/css/app.css
+++ b/src/client/css/app.css
@@ -1571,8 +1571,8 @@ a.well.well-sm:hover, a.well.well-sm:focus {
     margin-bottom: 30px;
   }
 
-    .saved-records-list #view-digital-item{
-      margin-bottom: 30px;
+  .saved-records-list #view-digital-item{
+    margin-bottom: 30px;
   }
 
 
@@ -1926,6 +1926,12 @@ a.well.well-sm:hover, a.well.well-sm:focus {
       padding-right: 10px;
       padding-left: 10px;
     }
+
+    /* Disabled Hover states */
+    .bookmark-text {
+      display: none !important;
+    }
+
 
 
     /* Header */

--- a/src/client/css/app.css
+++ b/src/client/css/app.css
@@ -1787,6 +1787,13 @@ a.well.well-sm:hover, a.well.well-sm:focus {
 
  @media (min-width: 768px) and (max-width: 991px) {
 
+    /* Disabled Hover states */
+    
+    .bookmark-text {
+      display: none !important;
+    }
+
+
     /* Homepage */
 
     #go-btn span {
@@ -1931,7 +1938,6 @@ a.well.well-sm:hover, a.well.well-sm:focus {
     .bookmark-text {
       display: none !important;
     }
-
 
 
     /* Header */


### PR DESCRIPTION
I was able to hide the hover state in the CSS for the mobile display per Jenny's suggestion but I just realized that we might want to find a way to target or detect touch devices since this will be an issue for tablets and other touch displays that will not be using the mobile stylings.