### PR TITLE
Hotfix: Cleanup - Remove client elasticsearch package from bower.json 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
     "angular-bootstrap": "1.3.x",
     "angular-resource": "1.4.x",
     "angular-animate": "1.4.x",
-    "elasticsearch": "8.2.x",
     "angular-ui-router": "~0.2.18",
     "angularUtils-pagination": "angular-utils-pagination#~0.9.2",
     "lodash": "~3.10.1",


### PR DESCRIPTION
Noticed while working on minification.

Remove client elasticsearch package from bower.json as we are now interacting with elasticsearch through django api


- [ ] @joshuago78 
- [ ] @jfranco-gri 