### PR TITLE
Bug/facets semicolons/555

### DIFF
--- a/src/server/api/views.py
+++ b/src/server/api/views.py
@@ -59,7 +59,8 @@ class Books(APIView):
     facet_categories = ['creator', 'subject', 'grp_contributor', 'language']
 
     def get(self, request, params, format=None):
-        params = params.replace(" & ", " %26 ")
+        params = params.replace(' & ', ' %26 ')
+        params = params.replace(';', '%3B')
         search_options = urllib.parse.parse_qs(params)
         es = Elasticsearch([ELASTICSEARCH_ADDRESS])
         body = es_functions.create_base_query()

--- a/test/e2e/search-results.e2e.spec.js
+++ b/test/e2e/search-results.e2e.spec.js
@@ -210,6 +210,13 @@ describe('Search Results', function() {
     });
   });
 
+  it('should work when facets have semicolons in them', function(){
+    resultsPage.addFacetOption('language', 'Spanish; Castilian');
+    resultsPage.numTotalHits.then(function(hits) {
+      expect(hits).toEqual(24);
+    });
+  });
+
   describe('Pagination', function(){
     var query = '';
 


### PR DESCRIPTION
Closes #555 

Fixed this bug the same way I fixed #535 (facets with '&' in them) -- I escaped the semicolons in the django books view prior to splitting up the param string into separate params.