### PR TITLE
Refactor/remove-elasticsearch-from-unit-tests/598

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -19,7 +19,6 @@ module.exports = function(config) {
       'src/client/bower_components/angular/angular.js',
       'src/client/bower_components/angular-ui-router/release/angular-ui-router.js',
       'src/client/bower_components/angular-resource/angular-resource.js',
-      'src/client/bower_components/elasticsearch/elasticsearch.angular.js',
       'src/client/bower_components/angular-animate/angular-animate.js',
       'src/client/bower_components/angularUtils-pagination/dirPagination.js',
       'src/client/bower_components/angular-print/angularPrint.js',

--- a/src/client/app/contributors/contributors.unit.spec.js
+++ b/src/client/app/contributors/contributors.unit.spec.js
@@ -13,7 +13,6 @@ describe('Contributors page tests', function() {
 	beforeEach(function(){
 		module('ui.router');
 		module('ui.bootstrap');
-		module('elasticsearch');
 		module('app.core');
 		module('app');
 		module('app.search');

--- a/src/client/app/core/search-sort.unit.spec.js
+++ b/src/client/app/core/search-sort.unit.spec.js
@@ -11,7 +11,6 @@ describe("Sorting tests", function() {
   beforeEach(function(){
     module('ui.router');
     module('ui.bootstrap');
-    module('elasticsearch');
     module('app.core');
     module('app');
     module('app.search');

--- a/src/client/app/search/search-controller.unit.spec.js
+++ b/src/client/app/search/search-controller.unit.spec.js
@@ -17,7 +17,6 @@ describe("Search Controller", function(){
   beforeEach(function(){
     module('ui.router');
     module('ui.bootstrap');
-    module('elasticsearch');
     module('app.core');
     module('app');
     module('app.search');


### PR DESCRIPTION
Closes #598 

I removed the elasticsearch module from karma.config.js and ran the tests, and about 30 tests failed in a similar way to how they did for @joshuago78 . I then removed the line where it loaded the elasticsearch module from the individual unit tests and now all tests are passing again, so I don't think we need to refactor beyond that.