### PR TITLE
Enhancement/expand adv search/623

### DIFF
--- a/src/client/app/advanced_search/advanced-search.controller.js
+++ b/src/client/app/advanced_search/advanced-search.controller.js
@@ -22,15 +22,7 @@
       $scope.filters = [{field: initialField, term: "", lastFilter: true}];
 
       // objs w/settings for each available adv field
-      $scope.fields = [
-          ADVANCED_SEARCH.keyword,
-          ADVANCED_SEARCH.title,
-          ADVANCED_SEARCH.creator,
-          ADVANCED_SEARCH.date,
-          ADVANCED_SEARCH.language,
-          ADVANCED_SEARCH.subject,
-          ADVANCED_SEARCH.grp_contributor,
-        ];
+      $scope.fields = ADVANCED_SEARCH;
     });
 
 

--- a/src/client/app/advanced_search/constants.js
+++ b/src/client/app/advanced_search/constants.js
@@ -5,103 +5,83 @@
     .constant('ADVANCED_SEARCH', {
       title: {
         paramName: 'adv_title',
-        display: 'Title',
-        searchKey: 'dublin_core.title'
+        display: 'Title'
       },
       creator: {
         paramName: 'adv_creator',
-        display: 'Creator',
-        searchKey: 'dublin_core.creator'
+        display: 'Creator'
       },
       date: {
         paramName: 'adv_date',
-        display: 'Date',
-        searchKey: 'dublin_core.date'
+        display: 'Date'
       },
       language: {
         paramName: 'adv_language',
-        display: 'Language',
-        searchKey: 'dublin_core.language'
+        display: 'Language'
       },
       subject: {
         paramName: 'adv_subject',
-        display: 'Subject',
-        searchKey: 'dublin_core.subject'
+        display: 'Subject'
       },
       grp_contributor: {
         paramName: 'adv_grp_contributor',
-        display: 'From',
-        searchKey: '_grp_contributor'
+        display: 'From'
       },
       keyword: {
         paramName: 'adv_keyword',
-        display: 'Keyword',
-        searchKey: 'keyword'
+        display: 'Keyword'
       },
       identifier: {
         paramName: 'adv_identifier',
-        display: 'Identifier',
-        searchKey: 'dublin_core.identifier'
+        display: 'Identifier'
       },
       publisher: {
         paramName: 'adv_publisher',
-        display: 'Publisher',
-        searchKey: 'dublin_core.publisher'
+        display: 'Publisher'
       },
       format: {
         paramName: 'adv_format',
-        display: 'Format',
-        searchKey: 'dublin_core.format'
+        display: 'Format'
       },
       type: {
         paramName: 'adv_type',
-        display: 'Type',
-        searchKey: 'dublin_core.type'
+        display: 'Type'
       },
       description: {
         paramName: 'adv_description',
-        display: 'Description',
-        searchKey: 'dublin_core.description'
+        display: 'Description'
       },
       provenance: {
         paramName: 'adv_provenance',
-        display: 'Provenance',
-        searchKey: 'dublin_core.provenance'
+        display: 'Provenance'
       },
       coverage: {
         paramName: 'adv_coverage',
-        display: 'Coverage',
-        searchKey: 'dublin_core.coverage'
+        display: 'Coverage'
       },
       relation: {
         paramName: 'adv_relation',
-        display: 'Relation',
-        searchKey: 'dublin_core.relation'
+        display: 'Relation'
       },
       source: {
         paramName: 'adv_source',
-        display: 'Source',
-        searchKey: 'dublin_core.source'
+        display: 'Source'
       },
       rights: {
         paramName: 'adv_rights',
-        display: 'Rights',
-        searchKey: 'dublin_core.rights'
+        display: 'Rights'
       },
       accrualMethod: {
         paramName: 'adv_accrualMethod',
-        display: 'Accrual Method',
-        searchKey: 'dublin_core.accrualMethod'
+        display: 'Accrual Method'
       },
       accrualPeriodicity: {
         paramName: 'adv_accrualPeriodicity',
-        display: 'Accrual Periodicity',
-        searchKey: 'dublin_core.accrualPeriodicity'
+        display: 'Accrual Periodicity'
       },
       audience: {
         paramName: 'adv_audience',
-        display: 'Audience',
-        searchKey: 'dublin_core.audience'
+        display: 'Audience'
       }
     });
 })();

--- a/src/client/app/advanced_search/constants.js
+++ b/src/client/app/advanced_search/constants.js
@@ -37,6 +37,71 @@
         paramName: 'adv_keyword',
         display: 'Keyword',
         searchKey: 'keyword'
+      },
+      identifier: {
+        paramName: 'adv_identifier',
+        display: 'Identifier',
+        searchKey: 'dublin_core.identifier'
+      },
+      publisher: {
+        paramName: 'adv_publisher',
+        display: 'Publisher',
+        searchKey: 'dublin_core.publisher'
+      },
+      format: {
+        paramName: 'adv_format',
+        display: 'Format',
+        searchKey: 'dublin_core.format'
+      },
+      type: {
+        paramName: 'adv_type',
+        display: 'Type',
+        searchKey: 'dublin_core.type'
+      },
+      description: {
+        paramName: 'adv_description',
+        display: 'Description',
+        searchKey: 'dublin_core.description'
+      },
+      provenance: {
+        paramName: 'adv_provenance',
+        display: 'Provenance',
+        searchKey: 'dublin_core.provenance'
+      },
+      coverage: {
+        paramName: 'adv_coverage',
+        display: 'Coverage',
+        searchKey: 'dublin_core.coverage'
+      },
+      relation: {
+        paramName: 'adv_relation',
+        display: 'Relation',
+        searchKey: 'dublin_core.relation'
+      },
+      source: {
+        paramName: 'adv_source',
+        display: 'Source',
+        searchKey: 'dublin_core.source'
+      },
+      rights: {
+        paramName: 'adv_rights',
+        display: 'Rights',
+        searchKey: 'dublin_core.rights'
+      },
+      accrualMethod: {
+        paramName: 'adv_accrualMethod',
+        display: 'Accrual Method',
+        searchKey: 'dublin_core.accrualMethod'
+      },
+      accrualPeriodicity: {
+        paramName: 'adv_accrualPeriodicity',
+        display: 'Accrual Periodicity',
+        searchKey: 'dublin_core.accrualPeriodicity'
+      },
+      audience: {
+        paramName: 'adv_audience',
+        display: 'Audience',
+        searchKey: 'dublin_core.audience'
       }
     });
 })();

--- a/src/client/app/app.config.routing.js
+++ b/src/client/app/app.config.routing.js
@@ -18,7 +18,7 @@
         controller: 'HomePageCtrl'
       })
       .state('searchResults', {
-        url: '/search?q&from&size&sort&creator&grp_contributor&language&subject&date_gte&date_lte&adv_creator&adv_date&adv_grp_contributor&adv_language&adv_subject&adv_title',
+        url: '/search?q&from&size&sort&creator&grp_contributor&language&subject&date_gte&date_lte&adv_creator&adv_date&adv_grp_contributor&adv_language&adv_subject&adv_title&adv_identifier&adv_publisher&adv_format&adv_type&adv_description&adv_provenance&adv_coverage&adv_relation&adv_source&adv_rights&adv_accrualMethod&adv_accrualPeriodicity&adv_audience',
         controller: 'SearchCtrl',
         templateUrl: config.app.root + '/search/search.results.html',
         params: {
@@ -34,7 +34,20 @@
           adv_language: { array: true },
           adv_subject: { array: true },
           adv_date: { array: true },
-          adv_title: { array: true }
+          adv_title: { array: true },
+          adv_identifier: { array: true },
+          adv_publisher: { array: true },
+          adv_format: { array: true },
+          adv_type: { array: true },
+          adv_description: { array: true },
+          adv_provenance: { array: true },
+          adv_coverage: { array: true },
+          adv_relation: { array: true },
+          adv_source: { array: true },
+          adv_rights: { array: true },
+          adv_accrualMethod: { array: true },
+          adv_accrualPeriodicity: { array: true },
+          adv_audience: { array: true }
         },
         resolve: {
           searchResults: function($rootScope, $stateParams, SearchService, DataService, SORT_MODES, ADVANCED_SEARCH){

--- a/src/client/app/core/search-service.js
+++ b/src/client/app/core/search-service.js
@@ -262,9 +262,9 @@
      * @param {string} term - value to filter for within the advanced field
      */
     function buildAdvancedField(field, term){
-      if(!field.searchKey){
+      if(!field.paramName){
         field = ADVANCED_SEARCH[field];
-        if(!field.searchKey){
+        if(!field.paramName){
           return false;
         }
       }

--- a/src/client/app/core/search-service.unit.spec.js
+++ b/src/client/app/core/search-service.unit.spec.js
@@ -307,19 +307,31 @@ describe('SearchService Unit Tests', function(){
   describe('Advanced Search Functions', function() {
     it('should populate and expose advancedFieldsList array', function(){
       expect(SearchService.advancedFieldsList).toBeTruthy();
-      expect(SearchService.advancedFieldsList.length).toEqual(7);
+      expect(SearchService.advancedFieldsList.length).toEqual(20);
       expect(SearchService.advancedFieldsList.indexOf('language')).toBeGreaterThan(-1);
       expect(SearchService.advancedFieldsList.indexOf('subject')).toBeGreaterThan(-1);
       expect(SearchService.advancedFieldsList.indexOf('grp_contributor')).toBeGreaterThan(-1);
       expect(SearchService.advancedFieldsList.indexOf('creator')).toBeGreaterThan(-1);
       expect(SearchService.advancedFieldsList.indexOf('title')).toBeGreaterThan(-1);
       expect(SearchService.advancedFieldsList.indexOf('date')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('identifier')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('publisher')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('format')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('type')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('description')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('provenance')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('coverage')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('relation')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('source')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('rights')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('accrualMethod')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('accrualPeriodicity')).toBeGreaterThan(-1);
+      expect(SearchService.advancedFieldsList.indexOf('audience')).toBeGreaterThan(-1);
     });
     it('should build advanced search field object', function(){
       var advDateFieldProps = {
         paramName: 'adv_date',
-        display: 'Date',
-        searchKey: 'dublin_core.date'
+        display: 'Date'
       };
 
       var advField = SearchService.buildAdvancedField(ADVANCED_SEARCH.date, 1900);

--- a/src/server/api/es_functions.py
+++ b/src/server/api/es_functions.py
@@ -40,7 +40,20 @@ def create_advanced_filters(field, terms):
               'adv_language': ['dublin_core.language.value', 'dublin_core.language.value.folded', 'dublin_core.language.value.stemmed'],
               'adv_title': ['dublin_core.title.value', 'dublin_core.title.value.folded', 'dublin_core.title.value.stemmed'],
               'adv_subject': ['dublin_core.subject.value', 'dublin_core.subject.value.folded', 'dublin_core.subject.value.stemmed'],
-              'adv_creator': ['dublin_core.creator.value', 'dublin_core.creator.value.folded', 'dublin_core.creator.value.stemmed', 'dublin_core.contributor.value', 'dublin_core.contributor.value.folded', 'dublin_core.contributor.value.stemmed']}
+              'adv_creator': ['dublin_core.creator.value', 'dublin_core.creator.value.folded', 'dublin_core.creator.value.stemmed', 'dublin_core.contributor.value', 'dublin_core.contributor.value.folded', 'dublin_core.contributor.value.stemmed'],
+              'adv_identifier': ['dublin_core.identifier.value', 'dublin_core.identifier.value.folded', 'dublin_core.identifier.value.stemmed'],
+              'adv_publisher': ['dublin_core.publisher.value', 'dublin_core.publisher.value.folded', 'dublin_core.publisher.value.stemmed'],
+              'adv_format': ['dublin_core.format.value', 'dublin_core.format.value.folded', 'dublin_core.format.value.stemmed'],
+              'adv_type': ['dublin_core.type.value', 'dublin_core.type.value.folded', 'dublin_core.type.value.stemmed'],
+              'adv_description': ['dublin_core.description.value', 'dublin_core.description.value.folded', 'dublin_core.description.value.stemmed'],
+              'adv_provenance': ['dublin_core.provenance.value', 'dublin_core.provenance.value.folded', 'dublin_core.provenance.value.stemmed'],
+              'adv_coverage': ['dublin_core.coverage.value', 'dublin_core.coverage.value.folded', 'dublin_core.coverage.value.stemmed'],
+              'adv_relation': ['dublin_core.relation.value', 'dublin_core.relation.value.folded', 'dublin_core.relation.value.stemmed'],
+              'adv_source': ['dublin_core.source.value', 'dublin_core.source.value.folded', 'dublin_core.source.value.stemmed'],
+              'adv_rights': ['dublin_core.rights.value', 'dublin_core.rights.value.folded', 'dublin_core.rights.value.stemmed'],
+              'adv_accrualMethod': ['dublin_core.accrualMethod.value', 'dublin_core.accrualMethod.value.folded', 'dublin_core.accrualMethod.value.stemmed'],
+              'adv_accrualPeriodicity': ['dublin_core.accrualPeriodicity.value', 'dublin_core.accrualPeriodicity.value.folded', 'dublin_core.accrualPeriodicity.value.stemmed'],
+              'adv_audience': ['dublin_core.audience.value', 'dublin_core.audience.value.folded', 'dublin_core.audience.value.stemmed']}
     field_term = fields.get(field)
     filters = []
     for term in terms:

--- a/src/server/api/views.py
+++ b/src/server/api/views.py
@@ -55,7 +55,10 @@ class Contributors(APIView):
 
 
 class Books(APIView):
-    advanced_fields = ['adv_date','adv_creator', 'adv_subject', 'adv_title', 'adv_grp_contributor', 'adv_language']
+    advanced_fields = ['adv_date','adv_creator', 'adv_subject', 'adv_title', 'adv_grp_contributor', 'adv_language',
+                       'adv_identifier', 'adv_publisher', 'adv_format', 'adv_type', 'adv_description', 'adv_provenance',
+                       'adv_relation', 'adv_source', 'adv_rights', 'adv_accrualMethod', 'adv_accrualPeriodicity',
+                       'adv_audience']
     facet_categories = ['creator', 'subject', 'grp_contributor', 'language']
 
     def get(self, request, params, format=None):


### PR DESCRIPTION
Closes #623 

I added all of the dublin core fields on the book detail page, so there are now 20 items in the Advanced Search drop-down menu, such that it overflows off the screen. Is this what we want, or do we want fewer dublin core fields? You can take a look on the branch `enhancement/expand-adv-search/623`
